### PR TITLE
Add required descriptor to avoid crash when creating a new RTV

### DIFF
--- a/renderer/d3d/pls_render_context_d3d_impl.cpp
+++ b/renderer/d3d/pls_render_context_d3d_impl.cpp
@@ -721,13 +721,16 @@ ID3D11RenderTargetView* PLSRenderTargetD3D::targetRTV()
 
         switch (m_targetFormat)
         {
+        case DXGI_FORMAT_R8G8B8A8_UNORM:
+        case DXGI_FORMAT_B8G8R8A8_UNORM:
+            desc.Format = m_targetFormat;
+
         case DXGI_FORMAT_R8G8B8A8_TYPELESS:
             desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
             break;
 
         default:
-            desc.Format = m_targetFormat;
-            break;
+            RIVE_UNREACHABLE();
         }
 
         VERIFY_OK(m_gpu->CreateRenderTargetView(m_targetTexture.Get(),

--- a/renderer/d3d/pls_render_context_d3d_impl.cpp
+++ b/renderer/d3d/pls_render_context_d3d_impl.cpp
@@ -716,10 +716,19 @@ ID3D11RenderTargetView* PLSRenderTargetD3D::targetRTV()
 {
     if (m_targetRTV == nullptr && m_targetTexture != nullptr)
     {
-        D3D11_RENDER_TARGET_VIEW_DESC desc;
-        ZeroMemory(&desc, sizeof(desc));
-        desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        D3D11_RENDER_TARGET_VIEW_DESC desc{};
         desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+
+        switch (m_targetFormat)
+        {
+        case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+            desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            break;
+
+        default:
+            desc.Format = m_targetFormat;
+            break;
+        }
 
         VERIFY_OK(m_gpu->CreateRenderTargetView(m_targetTexture.Get(),
                                                 &desc,

--- a/renderer/d3d/pls_render_context_d3d_impl.cpp
+++ b/renderer/d3d/pls_render_context_d3d_impl.cpp
@@ -716,8 +716,13 @@ ID3D11RenderTargetView* PLSRenderTargetD3D::targetRTV()
 {
     if (m_targetRTV == nullptr && m_targetTexture != nullptr)
     {
+        D3D11_RENDER_TARGET_VIEW_DESC desc;
+        ZeroMemory(&desc, sizeof(desc));
+        desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+
         VERIFY_OK(m_gpu->CreateRenderTargetView(m_targetTexture.Get(),
-                                                NULL,
+                                                &desc,
                                                 m_targetRTV.ReleaseAndGetAddressOf()));
     }
     return m_targetRTV.Get();


### PR DESCRIPTION
`CreateRenderTargetView` doesn't allow a NULL descriptor when the target texture is typeless. This change adds a descriptor (with the assumption that the texture in question is a 2D texture in R8G8B8A8_UNORM format).