### PR TITLE
Fix SIMD crash when running in UE4

### DIFF
--- a/renderer/pls_draw.cpp
+++ b/renderer/pls_draw.cpp
@@ -867,7 +867,10 @@ MidpointFanPathDraw::MidpointFanPathDraw(PLSRenderContext* context,
             {
                 // Measure the rotations of curves in batches of 4.
                 assert(j + 4 <= rotationIdx);
-                auto [tx0, ty0, tx1, ty1] = simd::load4x4f(&m_tangentPairs[j][0].x);
+
+                rive::simd::gvec<float, 4> tx0, ty0, tx1, ty1;
+                std::tie(tx0, ty0, tx1, ty1) = simd::load4x4f(&m_tangentPairs[j][0].x);
+
                 float4 numer = tx0 * tx1 + ty0 * ty1;
                 float4 denom_pow2 = (tx0 * tx0 + ty0 * ty0) * (tx1 * tx1 + ty1 * ty1);
                 float4 cosTheta = numer / simd::sqrt(denom_pow2);

--- a/renderer/pls_draw.cpp
+++ b/renderer/pls_draw.cpp
@@ -868,7 +868,7 @@ MidpointFanPathDraw::MidpointFanPathDraw(PLSRenderContext* context,
                 // Measure the rotations of curves in batches of 4.
                 assert(j + 4 <= rotationIdx);
 
-                rive::simd::gvec<float, 4> tx0, ty0, tx1, ty1;
+                float4 tx0, ty0, tx1, ty1;
                 std::tie(tx0, ty0, tx1, ty1) = simd::load4x4f(&m_tangentPairs[j][0].x);
 
                 float4 numer = tx0 * tx1 + ty0 * ty1;


### PR DESCRIPTION
In UE4, we would crash with no error message and a -1 exit code when trying to access `tx0`/`tx1`/`ty0`/`ty1`.

I'm not 100% sure of the cause, but my hunch is that it has to do with a mix of:

1. [SIMD operations requiring 16-byte memory alignment](https://stackoverflow.com/a/13014104)
2. C++14 (which UE4 uses) not having support for structured binding, so line 870 would actually declare a new array

Of course, this is compiled into the library, not as part of the UE4 project, which is why I'm not clear on how (2) comes into play. Regardless, explicitly declaring the four `gvec` values and their types, then using `std::tie` to unpack the return value of `load4x4f` gets us past the crash.

